### PR TITLE
Added argparse to requirements; it's not built-in in python2.6, but inbox.py works fine otherwise.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 gevent
 logbook
+argparse

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ settings.update(
     author_email='me@kennethreitz.com',
     url='https://github.com/kennethreitz/inbox.py',
     py_modules= ['inbox',],
-    install_requires=['gevent', 'logbook'],
+    install_requires=['gevent', 'logbook', 'argparse'],
     license='BSD',
     classifiers=(
         # 'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
A seriously boring pull request.
